### PR TITLE
Fix issue: PNG transparent area changed to black

### DIFF
--- a/projects/file-picker/package.json
+++ b/projects/file-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-awesome-uploader",
-  "version": "9.0.7",
+  "version": "9.0.8",
   "description": "Angular Library for uploading files with Real-Time Progress bar, File Preview, Drag && Drop and Custom Template with Multi Language support",
   "peerDependencies": {
     "@angular/common": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",

--- a/projects/file-picker/src/lib/file-picker.component.html
+++ b/projects/file-picker/src/lib/file-picker.component.html
@@ -27,7 +27,6 @@ class="file-input"
 <div class="cropperJsOverlay" *ngIf="currentCropperFile">
 <div class="cropperJsBox">
   <img
-    [style.display]="enableCropper ? 'none' : null"
     [src]="safeCropImgUrl"
     id="cropper-img"
     (load)="cropperImgLoaded($event)"

--- a/projects/file-picker/src/lib/file-picker.component.html
+++ b/projects/file-picker/src/lib/file-picker.component.html
@@ -27,6 +27,7 @@ class="file-input"
 <div class="cropperJsOverlay" *ngIf="currentCropperFile">
 <div class="cropperJsBox">
   <img
+    [style.display]="enableCropper ? 'none' : null"
     [src]="safeCropImgUrl"
     id="cropper-img"
     (load)="cropperImgLoaded($event)"

--- a/projects/file-picker/src/lib/file-picker.component.scss
+++ b/projects/file-picker/src/lib/file-picker.component.scss
@@ -16,6 +16,7 @@
 }
 #cropper-img {
   max-width: 60vw;
+  display: none;
 }
 #cropper-img img {
   width: 100%;

--- a/projects/file-picker/src/lib/file-picker.component.ts
+++ b/projects/file-picker/src/lib/file-picker.component.ts
@@ -42,8 +42,8 @@ export class FilePickerComponent implements OnInit, OnDestroy {
   @Output() validationError = new EventEmitter<ValidationError>();
   /** Emitted when file is added and passed validations. Not uploaded yet */
   @Output() fileAdded = new EventEmitter<FilePreviewModel>();
-   /** Emitted when file is removed from fileList */
-   @Output() fileRemoved = new EventEmitter<FilePreviewModel>();
+  /** Emitted when file is removed from fileList */
+  @Output() fileRemoved = new EventEmitter<FilePreviewModel>();
   /** Custom validator function */
   @Input() customValidator: (file: File) => Observable<boolean>;
   /** Whether to enable cropper. Default: disabled */
@@ -72,10 +72,12 @@ export class FilePickerComponent implements OnInit, OnDestroy {
   accept: string;
   files: FilePreviewModel[] = [];
   /** File extensions filter */
-  @Input() fileExtensions: String[];
+  @Input() fileExtensions: string[];
   cropper: any;
   /** Cropper options. */
-  @Input() cropperOptions: Object;
+  @Input() cropperOptions: object;
+  /** Cropped canvas options. */
+  @Input() croppedCanvasOptions: object = {};
   /** Files array for cropper. Will be shown equentially if crop enabled */
   filesForCropper: File[] = [];
   /** Current file to be shown in cropper*/
@@ -315,14 +317,14 @@ export class FilePickerComponent implements OnInit, OnDestroy {
 
   /** Validates file extension */
   isValidExtension(file: File, fileName: string): boolean {
-      if (!this.fileExtensions) {return true; }
-      const extension = fileName.split('.').pop();
-      const fileExtensions = this.fileExtensions.map(ext => ext.toLowerCase());
-      if (fileExtensions.indexOf(extension.toLowerCase()) === -1) {
-        this.validationError.next({file: file, error: FileValidationTypes.extensions});
-        return false;
-      }
-      return true;
+    if (!this.fileExtensions) {return true; }
+    const extension = fileName.split('.').pop();
+    const fileExtensions = this.fileExtensions.map(ext => ext.toLowerCase());
+    if (fileExtensions.indexOf(extension.toLowerCase()) === -1) {
+      this.validationError.next({file: file, error: FileValidationTypes.extensions});
+      return false;
+    }
+    return true;
   }
   /** Validates selected file size and total file size */
   isValidSize(file: File, size: number): boolean {
@@ -362,7 +364,7 @@ export class FilePickerComponent implements OnInit, OnDestroy {
   /** when crop button submitted */
   onCropSubmit(): void {
     this.cropper
-      .getCroppedCanvas()
+      .getCroppedCanvas(this.croppedCanvasOptions)
       .toBlob(this.blobFallBack.bind(this), 'image/png');
   }
   /** After crop submit */

--- a/projects/file-picker/src/lib/file-picker.component.ts
+++ b/projects/file-picker/src/lib/file-picker.component.ts
@@ -363,7 +363,7 @@ export class FilePickerComponent implements OnInit, OnDestroy {
   onCropSubmit(): void {
     this.cropper
       .getCroppedCanvas()
-      .toBlob(this.blobFallBack.bind(this), 'image/jpeg');
+      .toBlob(this.blobFallBack.bind(this), 'image/png');
   }
   /** After crop submit */
   blobFallBack(blob: Blob): void {


### PR DESCRIPTION
fix black area that should be transparent for cropped images

We are cropping only images for sure. So, we don't need to check that it image in toBlob function. So the type after toBlob should be fixed "image/" I changed it from "image/jpeg" to "image/png", because we can crop png images with transparent areas for sure and also we can crop just part of jpeg image too and it will also have transparent area. But "image/jpeg" automatically converts transparent areas to black. "image/png" type is fixing that.