### PR TITLE
Browse button type defined as 'button'

### DIFF
--- a/projects/file-picker/src/lib/file-drop/file-drop.component.html
+++ b/projects/file-picker/src/lib/file-drop/file-drop.component.html
@@ -14,7 +14,7 @@
               <div class="content-center-text">
                 {{captions?.dropzone?.or}}
               </div>
-              <button class="file-browse-button">
+              <button class="file-browse-button" type="button">
                 {{captions?.dropzone?.browse}}
               </button>
     </div>


### PR DESCRIPTION
HTML5 dictates that all buttons inside \<form\> whose type is not defined default to type="submit". This proves to be a problem when using this uploader inside a form, causing form to be pre-maturely submitted.