### PR TITLE
Fix bug when multiple files are dropped

### DIFF
--- a/projects/file-picker/src/lib/file-picker.component.ts
+++ b/projects/file-picker/src/lib/file-picker.component.ts
@@ -136,11 +136,11 @@ export class FilePickerComponent implements OnInit, OnDestroy {
         const fileEntry = droppedFile.fileEntry as FileSystemFileEntry;
         fileEntry.file((file: File) => {
           filesForUpload.push(file);
-          runInInjectionContext((this.injector), () => {
-            this.handleFiles(filesForUpload).pipe(
-              takeUntilDestroyed()
-            ).subscribe();
-          });
+        });
+        runInInjectionContext((this.injector), () => {
+          this.handleFiles(filesForUpload).pipe(
+            takeUntilDestroyed()
+          ).subscribe();
         });
       } else {
         // It was a directory (empty directories are added, otherwise only files)


### PR DESCRIPTION
Fixes #117 

It was introduced in this fix https://github.com/vugar005/ngx-awesome-uploader/pull/115

There was mistake and handleFiles was called multiple times (in each iteration).